### PR TITLE
Update ideal.js

### DIFF
--- a/view/frontend/web/js/view/payment/gateway/method-renderer/ideal.js
+++ b/view/frontend/web/js/view/payment/gateway/method-renderer/ideal.js
@@ -56,7 +56,7 @@ define(
             },
 
             initialize: function () {
-                this._super().observe('issuerId');
+                this._super()._super().observe('issuerId');
 
                 if (config.is_preselected) {
                     selectPaymentMethodAction(this.getData());

--- a/view/frontend/web/js/view/payment/gateway/method-renderer/ideal.js
+++ b/view/frontend/web/js/view/payment/gateway/method-renderer/ideal.js
@@ -56,7 +56,7 @@ define(
             },
 
             initialize: function () {
-                this._super()._super().observe('issuerId');
+                this._super();
 
                 if (config.is_preselected) {
                     selectPaymentMethodAction(this.getData());
@@ -64,6 +64,12 @@ define(
                 }
 
                 self = this;
+            },
+
+            initObservable: function () {
+                this._super()
+                    .observe('issuerId')
+                return this;
             },
 
             /**


### PR DESCRIPTION
this._super()._super().observe('issuerId');   >> double super is needed because of double inheritance.
This was throwing an error in my JS > It didn't know the property observe on this keyword.