### PR TITLE
Remove trailing comma (IE11)

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer.js
+++ b/view/frontend/web/js/view/payment/method-renderer.js
@@ -103,7 +103,7 @@ define(
             {type: 'multisafepay_wellnessgiftcard', component: baseRenderer},
             {type: 'multisafepay_wijncadeau', component: baseRenderer},
             {type: 'multisafepay_winkelcheque', component: baseRenderer},
-            {type: 'multisafepay_yourgift', component: baseRenderer},
+            {type: 'multisafepay_yourgift', component: baseRenderer}
         );
 
         /** Add view logic here if needed */


### PR DESCRIPTION
For IE11, this avoids an error while rendering the payment widget.
See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas#browser_compatibility