### PR TITLE
Header elements visible on checkout pages

### DIFF
--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
         <css src="https://pay.multisafepay.com/sdk/components/v1/components.css"  src_type="url" rel="stylesheet" type="text/css"  />
     </head>


### PR DESCRIPTION
Hi,

Different header elements are visible on checkout pages. Normally these elements are invisible. 

I found out that this is caused by adding a `layout` attribute inside `checkout_index_index.xml`. Adding a layout attribute like `layout="1column"` in xml files will override the page layout of Magento.

In `vendor/magento/module-checkout/view/frontend/layout/checkout_index_index.xml` you can see that `layout="checkout"` is used. `vendor/magento/module-checkout/view/frontend/page_layout/checkout.xml` is using `<update handle="empty"/>`.

By using `empty` as layout handle a lot of blocks aren't rendered.