### PR TITLE
Use _query parameter to pass query parameter instead of concatenation

### DIFF
--- a/Controller/Connect/Success.php
+++ b/Controller/Connect/Success.php
@@ -124,7 +124,7 @@ class Success extends Action
         if ($customReturnUrl) {
             $redirectUrl = $this->resultRedirectFactory->create()->setUrl($customReturnUrl);
         } else {
-            $redirectUrl = $this->_redirect('checkout/onepage/success?utm_nooverride=1');
+            $redirectUrl = $this->_redirect('checkout/onepage/success', ['_query' => 'utm_nooverride=1']);
         }
 
         $order->addCommentToStatusHistory('User redirected to the success page.');


### PR DESCRIPTION
Our client raised an issue that the `utm_nooverride` parameter is being ignored. When they went and investigated, they found this URL in their analytics; `https://example.com/checkout/onepage/success?utm_nooverride=1/`

Because of the trailing slash, the parameter isn't picked up. 

Here's how I reproduced it:

```
$ magerun2 dev:console
>>> $response = $di->get('Magento\Framework\App\ResponseInterface');
=> Magento\Framework\App\Response\Http\Interceptor {#5678}
>>> $di->get('\Magento\Framework\App\Response\RedirectInterface')->redirect($response, 'checkout/onepage/success?utm_nooverride=1');
=> null
>>> echo $response->getHeader('Location')->getUri();
https://example.com/checkout/onepage/success?utm_nooverride=1/⏎
```

Or, shorter;

```
$ magerun2 dev:console
`>>> echo $di->get('\Magento\Framework\UrlInterface')->getUrl('checkout/onepage/success?utm_nooverride=1');`
https://example.com/checkout/onepage/success?utm_nooverride=1/⏎
```

The problem is that the extension now passes the utm_nooverride parameter in the path itself, instead of passing it as an argument, as it should. You can try this;

```
$ magerun2 dev:console
>>> $response = $di->get('Magento\Framework\App\ResponseInterface');
=> Magento\Framework\App\Response\Http\Interceptor {#5678}
>>> $di->get('\Magento\Framework\App\Response\RedirectInterface')->redirect($response, 'checkout/onepage/success', ['_query' => 'utm_nooverride=1']);
=> null
>>> echo $response->getHeader('Location')->getUri();
https://example.com/checkout/onepage/success/?utm_nooverride=1⏎
```

That fixes it and the parameter will be picked up by analytics.