### PR TITLE
Only set the cards config to enabled when the payment type is credit card instead of redirect

### DIFF
--- a/ViewModel/PaymentConfig.php
+++ b/ViewModel/PaymentConfig.php
@@ -11,6 +11,7 @@ use Magento\Framework\UrlInterface;
 use Magento\Framework\View\Element\Block\ArgumentInterface;
 use Magento\Quote\Api\Data\CartInterface;
 use Magento\Quote\Api\Data\CartItemInterface;
+use MultiSafepay\ConnectAdminhtml\Model\Config\Source\CardPaymentTypes;
 use MultiSafepay\ConnectCore\Model\Ui\ConfigProviderPool;
 use MultiSafepay\ConnectCore\Model\Ui\Gateway\AmexConfigProvider;
 use MultiSafepay\ConnectCore\Model\Ui\Gateway\CreditCardConfigProvider;
@@ -87,7 +88,7 @@ class PaymentConfig implements ArgumentInterface
                 (int)$this->getQuote()->getStoreId()
             );
 
-            if ($paymentConfig && isset($paymentConfig['payment_type']) && $paymentConfig['active']) {
+            if ($paymentConfig && isset($paymentConfig['payment_type']) && $paymentConfig['payment_type'] === CardPaymentTypes::CREDIT_CARD_COMPONENT_PAYMENT_TYPE && $paymentConfig['active']) {
                 $result[$methodCode] = [
                     "types" => self::DEFAULT_CARD_TYPES,
                     "flags" => $this->getCardFlagByMethodCode($methodCode),


### PR DESCRIPTION
This prevents slow API calls to fetch short lived API tokens on customer section data reload when it's not actually needed.

In our shop, we don't use the credit card component (yet), but use the redirect credit card flow. So we don't need short lived API tokens in the frontend. In our PHP-FPM slow logs, I saw these kind of requests:

```
[21-Oct-2021 07:34:15]  [pool www] pid 2963
script_filename = /data/web/magento2/pub/index.php
[0x00007fb530c15ef0] curl_multi_select() /data/web/magento2/vendor/guzzlehttp/guzzle/src/Handler/CurlMultiHandler.php:121
[0x00007fb530c15e40] tick() /data/web/magento2/vendor/guzzlehttp/guzzle/src/Handler/CurlMultiHandler.php:145
[0x00007fb530c15dc0] execute() /data/web/magento2/vendor/guzzlehttp/promises/src/Promise.php:248
[0x00007fb530c15d20] invokeWaitFn() /data/web/magento2/vendor/guzzlehttp/promises/src/Promise.php:224
[0x00007fb530c15ca0] waitIfPending() /data/web/magento2/vendor/guzzlehttp/promises/src/Promise.php:269
[0x00007fb530c15c10] invokeWaitList() /data/web/magento2/vendor/guzzlehttp/promises/src/Promise.php:226
[0x00007fb530c15b90] waitIfPending() /data/web/magento2/vendor/guzzlehttp/promises/src/Promise.php:62
[0x00007fb530c15b00] wait() /data/web/magento2/vendor/php-http/guzzle6-adapter/src/Promise.php:94
[0x00007fb530c15a70] wait() /data/web/magento2/vendor/php-http/guzzle6-adapter/src/Client.php:57
[0x00007fb530c159f0] sendRequest() /data/web/magento2/vendor/multisafepay/php-sdk/src/Client/Client.php:158
[0x00007fb530c15940] createGetRequest() /data/web/magento2/vendor/multisafepay/php-sdk/src/Api/ApiTokenManager.php:25
[0x00007fb530c158c0] get() /data/web/magento2/vendor/multisafepay/magento2-core/Model/Ui/GenericConfigProvider.php:185
[0x00007fb530c15820] getApiToken() /data/web/magento2/vendor/multisafepay/magento2-frontend/CustomerData/PaymentRequest.php:87
[0x00007fb530c15780] getSectionData() /data/web/magento2/vendor/magento/module-customer/CustomerData/SectionPool.php:90
[0x00007fb530c156d0] getSectionDataByNames() /data/web/magento2/vendor/magento/module-customer/CustomerData/SectionPool.php:60
[0x00007fb530c15630] getSectionsData() /data/web/magento2/vendor/magento/module-customer/Controller/Section/Load.php:80
[0x00007fb530c15560] execute() /data/web/magento2/vendor/magento/framework/Interception/Interceptor.php:58
[0x00007fb530c154e0] ___callParent() /data/web/magento2/vendor/magento/framework/Interception/Interceptor.php:138
[0x00007fb530c15390] Magento\Framework\Interception\{closure}() /data/web/magento2/vendor/magento/framework/Interception/Interceptor.php:153
[0x00007fb530c152b0] ___callPlugins() /data/web/magento2/generated/code/Magento/Customer/Controller/Section/Load/Interceptor.php:23
```

Turns out the customer data was still fetching API tokens, even though the frontend never needs them. This prevents that. As an added bonus this will relieve the pressure on the MSP servers 🎉 
