### PR TITLE
Migrate CI Docker images to GitHub Container Registry

### DIFF
--- a/.github/workflows/magento-integration-tests.yml
+++ b/.github/workflows/magento-integration-tests.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
 
       - name: Start Docker
-        run: docker run --detach --name magento-project-community-edition michielgerritsen/magento-project-community-edition:${{ matrix.PHP_VERSION }}-magento${{ matrix.MAGENTO_VERSION }}
+        run: docker run --detach --name magento-project-community-edition ghcr.io/controlaltdelete-nl/magento2-in-a-box/magento-project-community-edition:${{ matrix.PHP_VERSION }}-magento${{ matrix.MAGENTO_VERSION }}
 
       - name: Upload our code into the docker container
         run: docker cp "$(pwd)" magento-project-community-edition:/data/extensions/

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -36,7 +36,7 @@ jobs:
           path: module-src
 
       - name: Start Docker
-        run: docker run --detach --name magento-project-community-edition michielgerritsen/magento-project-community-edition:${{ matrix.PHP_VERSION }}-magento${{ matrix.MAGENTO_VERSION }}
+        run: docker run --detach --name magento-project-community-edition ghcr.io/controlaltdelete-nl/magento2-in-a-box/magento-project-community-edition:${{ matrix.PHP_VERSION }}-magento${{ matrix.MAGENTO_VERSION }}
 
       - name: Extract branch name
         id: extract_branch

--- a/.github/workflows/release-actions.yml
+++ b/.github/workflows/release-actions.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 0
 
       - name: Start Docker
-        run: docker run --detach --name magento-project-community-edition michielgerritsen/magento-project-community-edition:${{ matrix.PHP_VERSION }}-magento${{ matrix.MAGENTO_VERSION }}
+        run: docker run --detach --name magento-project-community-edition ghcr.io/controlaltdelete-nl/magento2-in-a-box/magento-project-community-edition:${{ matrix.PHP_VERSION }}-magento${{ matrix.MAGENTO_VERSION }}
 
       - name: Upload our code into the docker container
         run: docker cp "$(pwd)" magento-project-community-edition:/data/extensions/


### PR DESCRIPTION
The michielgerritsen/magento-project-community-edition images have moved to
ghcr.io/controlaltdelete-nl/magento2-in-a-box/magento-project-community-edition.