### PR TITLE
Add Mage-OS to the CI matrix

### DIFF
--- a/.github/workflows/magento-integration-tests.yml
+++ b/.github/workflows/magento-integration-tests.yml
@@ -24,9 +24,14 @@ jobs:
       matrix:
         include:
           - PHP_VERSION: php74-fpm
-            MAGENTO_VERSION: 2.3.7-p4
+            IMAGE: magento-project-community-edition
+            IMAGE_VERSION: magento2.3.7-p4
           - PHP_VERSION: php82-fpm
-            MAGENTO_VERSION: 2.4.6-p12
+            IMAGE: magento-project-community-edition
+            IMAGE_VERSION: magento2.4.6-p12
+          - PHP_VERSION: php84-fpm
+            IMAGE: mage-os-community-edition
+            IMAGE_VERSION: mage-os3.3.0
 
     steps:
       - uses: actions/checkout@v5
@@ -34,7 +39,7 @@ jobs:
           fetch-depth: 0
 
       - name: Start Docker
-        run: docker run --detach --name magento-project-community-edition ghcr.io/controlaltdelete-nl/magento2-in-a-box/magento-project-community-edition:${{ matrix.PHP_VERSION }}-magento${{ matrix.MAGENTO_VERSION }}
+        run: docker run --detach --name magento-project-community-edition ghcr.io/controlaltdelete-nl/magento2-in-a-box/${{ matrix.IMAGE }}:${{ matrix.PHP_VERSION }}-${{ matrix.IMAGE_VERSION }}
 
       - name: Upload our code into the docker container
         run: docker cp "$(pwd)" magento-project-community-edition:/data/extensions/

--- a/.github/workflows/magento-integration-tests.yml
+++ b/.github/workflows/magento-integration-tests.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
 
       - name: Start Docker
-        run: docker run --detach --name magento-project-community-edition michielgerritsen/magento-project-community-edition:${{ matrix.PHP_VERSION }}-magento${{ matrix.MAGENTO_VERSION }}
+        run: docker run --detach --name magento-project-community-edition ghcr.io/controlaltdelete-nl/magento2-in-a-box/magento-project-community-edition:${{ matrix.PHP_VERSION }}-magento${{ matrix.MAGENTO_VERSION }}
 
       - name: Upload our code into the docker container
         run: docker cp "$(pwd)" magento-project-community-edition:/data/extensions/

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -36,7 +36,7 @@ jobs:
           path: module-src
 
       - name: Start Docker
-        run: docker run --detach --name magento-project-community-edition michielgerritsen/magento-project-community-edition:${{ matrix.PHP_VERSION }}-magento${{ matrix.MAGENTO_VERSION }}
+        run: docker run --detach --name magento-project-community-edition ghcr.io/controlaltdelete-nl/magento2-in-a-box/magento-project-community-edition:${{ matrix.PHP_VERSION }}-magento${{ matrix.MAGENTO_VERSION }}
 
       - name: Extract branch name
         id: extract_branch

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -25,9 +25,14 @@ jobs:
       matrix:
         include:
           - PHP_VERSION: php74-fpm
-            MAGENTO_VERSION: 2.3.7-p4
+            IMAGE: magento-project-community-edition
+            IMAGE_VERSION: magento2.3.7-p4
           - PHP_VERSION: php82-fpm
-            MAGENTO_VERSION: 2.4.6-p12
+            IMAGE: magento-project-community-edition
+            IMAGE_VERSION: magento2.4.6-p12
+          - PHP_VERSION: php84-fpm
+            IMAGE: mage-os-community-edition
+            IMAGE_VERSION: mage-os3.3.0
 
     steps:
       - uses: actions/checkout@v5
@@ -36,7 +41,7 @@ jobs:
           path: module-src
 
       - name: Start Docker
-        run: docker run --detach --name magento-project-community-edition ghcr.io/controlaltdelete-nl/magento2-in-a-box/magento-project-community-edition:${{ matrix.PHP_VERSION }}-magento${{ matrix.MAGENTO_VERSION }}
+        run: docker run --detach --name magento-project-community-edition ghcr.io/controlaltdelete-nl/magento2-in-a-box/${{ matrix.IMAGE }}:${{ matrix.PHP_VERSION }}-${{ matrix.IMAGE_VERSION }}
 
       - name: Extract branch name
         id: extract_branch

--- a/.github/workflows/release-actions.yml
+++ b/.github/workflows/release-actions.yml
@@ -25,9 +25,14 @@ jobs:
       matrix:
         include:
           - PHP_VERSION: php74-fpm
-            MAGENTO_VERSION: 2.3.7-p4
+            IMAGE: magento-project-community-edition
+            IMAGE_VERSION: magento2.3.7-p4
           - PHP_VERSION: php82-fpm
-            MAGENTO_VERSION: 2.4.6-p12
+            IMAGE: magento-project-community-edition
+            IMAGE_VERSION: magento2.4.6-p12
+          - PHP_VERSION: php84-fpm
+            IMAGE: mage-os-community-edition
+            IMAGE_VERSION: mage-os3.3.0
 
     steps:
       - uses: actions/checkout@v5
@@ -35,7 +40,7 @@ jobs:
           fetch-depth: 0
 
       - name: Start Docker
-        run: docker run --detach --name magento-project-community-edition ghcr.io/controlaltdelete-nl/magento2-in-a-box/magento-project-community-edition:${{ matrix.PHP_VERSION }}-magento${{ matrix.MAGENTO_VERSION }}
+        run: docker run --detach --name magento-project-community-edition ghcr.io/controlaltdelete-nl/magento2-in-a-box/${{ matrix.IMAGE }}:${{ matrix.PHP_VERSION }}-${{ matrix.IMAGE_VERSION }}
 
       - name: Upload our code into the docker container
         run: docker cp "$(pwd)" magento-project-community-edition:/data/extensions/

--- a/.github/workflows/release-actions.yml
+++ b/.github/workflows/release-actions.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 0
 
       - name: Start Docker
-        run: docker run --detach --name magento-project-community-edition michielgerritsen/magento-project-community-edition:${{ matrix.PHP_VERSION }}-magento${{ matrix.MAGENTO_VERSION }}
+        run: docker run --detach --name magento-project-community-edition ghcr.io/controlaltdelete-nl/magento2-in-a-box/magento-project-community-edition:${{ matrix.PHP_VERSION }}-magento${{ matrix.MAGENTO_VERSION }}
 
       - name: Upload our code into the docker container
         run: docker cp "$(pwd)" magento-project-community-edition:/data/extensions/


### PR DESCRIPTION
Stacked on top of #16. GitHub cannot base a pull request on a branch that
lives in a fork, so this pull request also contains the commit from #16.
Please merge #16 first; this diff then reduces to the Mage-OS commit alone.

The GHCR registry also publishes Mage-OS images, as a separate package
(mage-os-community-edition) rather than extra tags on the Magento one. The
image name therefore becomes a matrix value: MAGENTO_VERSION is replaced by
IMAGE and IMAGE_VERSION, which together form the full tag.

Adds a Mage-OS 3.3.0 leg on PHP 8.4 to every matrix.